### PR TITLE
fix bug - snr levels should be strict int

### DIFF
--- a/noisyspeech_synthesizer.py
+++ b/noisyspeech_synthesizer.py
@@ -12,7 +12,7 @@ from audiolib import audioread, audiowrite, snr_mixer
 def main(cfg):
     snr_lower = float(cfg["snr_lower"])
     snr_upper = float(cfg["snr_upper"])
-    total_snrlevels = float(cfg["total_snrlevels"])
+    total_snrlevels = int(cfg["total_snrlevels"])
     
     clean_dir = os.path.join(os.path.dirname(__file__), 'clean_train')
     if cfg["speech_dir"]!='None':


### PR DESCRIPTION
fixes this bug
```
Traceback (most recent call last):
  File "e:/MS-SNSD-master/noisyspeech_synthesizer.py", line 125, in <module>
    main(cfg._sections[args.cfg_str])
  File "e:/MS-SNSD-master/noisyspeech_synthesizer.py", line 48, in main
    SNR = np.linspace(snr_lower, snr_upper, total_snrlevels)
  File "<__array_function__ internals>", line 6, in linspace
  File ".\anaconda3\lib\site-packages\numpy\core\function_base.py", line 121, in linspace
    .format(type(num)))
TypeError: object of type <class 'float'> cannot be safely interpreted as an integer.
```