### PR TITLE
Fix SNR calculate error, total_snrlevels, requirements.txt

### DIFF
--- a/audiolib.py
+++ b/audiolib.py
@@ -65,7 +65,7 @@ def snr_mixer(clean, noise, snr):
     rmsnoise = (noise**2).mean()**0.5
     
     # Set the noise level for a given SNR
-    noisescalar = np.sqrt(rmsclean / (10**(snr/20)) / rmsnoise)
+    noisescalar = rmsclean / (10**(snr/20)) / rmsnoise
     noisenewlevel = noise * noisescalar
     noisyspeech = clean + noisenewlevel
     return clean, noisenewlevel, noisyspeech

--- a/noisyspeech_synthesizer.cfg
+++ b/noisyspeech_synthesizer.cfg
@@ -21,8 +21,8 @@ audio_length: 10
 silence_length: 0.2
 total_hours: 1 
 snr_lower: 0
-snr_upper: 40
-total_snrlevels: 5  
+snr_upper: 20
+total_snrlevels: 5
 
 noise_dir: None
 speech_dir: None

--- a/noisyspeech_synthesizer.py
+++ b/noisyspeech_synthesizer.py
@@ -12,7 +12,7 @@ from audiolib import audioread, audiowrite, snr_mixer
 def main(cfg):
     snr_lower = float(cfg["snr_lower"])
     snr_upper = float(cfg["snr_upper"])
-    total_snrlevels = float(cfg["total_snrlevels"])
+    total_snrlevels = int(cfg["total_snrlevels"])
     
     clean_dir = os.path.join(os.path.dirname(__file__), 'clean_train')
     if cfg["speech_dir"]!='None':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 numpy
-glob
+glob2
 soundfile
 scipy
-os
 configparser


### PR DESCRIPTION
- I think np.sqrt in line 68 of audiolib.py should be removed in order to get correct snr.
- total_snrlevels should be a integer parameter in np.linspace(snr_lower, snr_upper, total_snrlevels) (line 47 of noisyspeech_synthesizer.py)
- I removed unnecessary standard library "os" and changed glob to glob2 to accurately download libraries in requirements.txt